### PR TITLE
订正 TrMenu 拼写

### DIFF
--- a/src/plugins/plugins/trmenu/README.md
+++ b/src/plugins/plugins/trmenu/README.md
@@ -1,5 +1,5 @@
 ---
-title: 'Trmenu'
+title: 'TrMenu'
 dir:
   link: true 
 ---


### PR DESCRIPTION
另外，我注意到文档中还有 MythicMobs 和 WorldGuard

这两个已经有中文文档了

MythicMobs：https://gitlab.com/TranslatedByShark/Mythic-Manual-CN/-/wikis/home
WorldGuard：https://snowcutieowo.github.io/WorldGuard

或许没有必要再写这两个插件的文档了
